### PR TITLE
use domain in config, fixes rss

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,9 @@
-import { defineConfig } from 'astro/config';
-import mdx from '@astrojs/mdx';
-
-import sitemap from '@astrojs/sitemap';
+import { defineConfig } from "astro/config";
+import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://devthedevel.github.io/personal_website',
-	integrations: [mdx(), sitemap()],
+  site: "https://www.devthedevel.xyz/",
+  integrations: [mdx(), sitemap()],
 });


### PR DESCRIPTION
![image](https://github.com/devthedevel/personal_website/assets/6486417/10656187-bef0-437f-949c-990836590cb5)

since the site in your astro config is a github pages deployment isn't where the actual deployment is, 404 in the rss feed

i fix

also i have prettier installed so it format, sori (but not sori)